### PR TITLE
Fix for: sleep not defined error in Lambda

### DIFF
--- a/Challenge_1_ML_Cloud/greengrassSagemakerInference.py
+++ b/Challenge_1_ML_Cloud/greengrassSagemakerInference.py
@@ -35,7 +35,7 @@ def greengrassSagemakerInference_run():
     vidcap=cv2.VideoCapture(0)
     vidcap.open(0)
     #this may be required if camera needs warm up.
-    sleep(1) 
+    time.sleep(1) 
     retval, image = vidcap.read()
     vidcap.release()
     image = cv2.resize(image, (300, 300))


### PR DESCRIPTION
Getting these errors on the device:

[2018-08-30T15:22:32.987-04:00][INFO]-Function arn:aws:lambda:us-east-1:111652037296:function:GreenGrassSagemakerInference:1 Worker 766b0699-3afc-48bb-7940-d88be17d0fbc Memory Size 98304 KB Max Memory Used 55692 KB
[2018-08-30T15:22:32.987-04:00][ERROR]-worker ungracefully killed arn:aws:lambda:us-east-1:111652037296:function:GreenGrassSagemakerInference:1 766b0699-3afc-48bb-7940-d88be17d0fbc &{3977 256 0xc4202ec000}

==> /greengrass/ggc/var/log/user/us-east-1/111652037296/GreenGrassSagemakerInference.log <==
[2018-08-30T15:45:20.758-04:00][FATAL]-lambda_runtime.py:108,Failed to import handler function "greengrassHelloWorld.function_handler" due to exception: global name 'sleep' is not defined
[2018-08-30T15:45:20.759-04:00][FATAL]-lambda_runtime.py:356,Failed to initialize Lambda runtime due to exception: global name 'sleep' is not defined